### PR TITLE
Fix core module count docs

### DIFF
--- a/REBUILD_DOCS/MODULE_BOUNDARIES_SPEC.md
+++ b/REBUILD_DOCS/MODULE_BOUNDARIES_SPEC.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This document defines clear boundaries between the 5 core modules, their interfaces, and communication patterns. The system has been simplified from the original design to reduce complexity while maintaining all functionality through a graph-first approach where ALL data (knowledge and PM) lives in Neo4j.
+This document defines clear boundaries between the 6 core modules, their interfaces, and communication patterns. The system has been simplified from the original design to reduce complexity while maintaining all functionality through a graph-first approach where ALL data (knowledge and PM) lives in Neo4j.
 
 ## Module Design Principles
 

--- a/REBUILD_DOCS/README.md
+++ b/REBUILD_DOCS/README.md
@@ -36,7 +36,7 @@ The **[development_tools/](./development_tools/)** folder contains tools used du
 ## Key Design Decisions
 
 1. **Neo4j Database** - Chosen for better AI training data representation
-2. **5 Core Modules** - Simplified from original 10+ module design
+2. **6 Core Modules** - Simplified from original 10+ module design
 3. **Graph-First Architecture** - All data (knowledge + PM) in one graph
 4. **Event-Driven Sync** - Automatic coordination between components
 5. **Auto-Maintained Touchpoints** - Claude Code maintains navigation system
@@ -54,7 +54,7 @@ For developers new to the project:
 ## Quick Reference
 
 - **Database**: Neo4j (all data in one graph)
-- **Core Modules**: Query Engine, Graph Executor, PM Assistant, Response Formatter, Context Manager
+- **Core Modules**: Query Engine, Graph Executor, PM Assistant, Response Formatter, Context Manager, API Gateway
 - **Languages**: TypeScript (primary), Python (tools)
 - **Architecture**: Event-driven, graph-first, AI-agent friendly
 - **Development Timeline**: 12 weeks for full implementation

--- a/REBUILD_DOCS/REBUILD_PRD.md
+++ b/REBUILD_DOCS/REBUILD_PRD.md
@@ -572,7 +572,7 @@ All module and system configuration will be managed via a single `.env` file at 
 
 ### Applied to This Build
 1. Neo4j chosen for better AI training representation
-2. Simplified to 5 core modules with clear boundaries
+2. Simplified to 6 core modules with clear boundaries
 3. Graph-first design stores everything in one place
 4. Dynamic context sizing based on model capabilities
 5. Auto-maintained touchpoints via Claude Code integration

--- a/REBUILD_DOCS/development_tools/SUB_AGENT_ORCHESTRATION_SPEC.md
+++ b/REBUILD_DOCS/development_tools/SUB_AGENT_ORCHESTRATION_SPEC.md
@@ -12,7 +12,7 @@ This tool is used exclusively during development to help build the Enterprise Kn
 
 ### 1. How It Helps Development
 
-The orchestration system helps developers build the system's 5 core modules more efficiently:
+The orchestration system helps developers build the system's 6 core modules more efficiently:
 
 ```mermaid
 graph TD
@@ -21,6 +21,7 @@ graph TD
     O --> PM[PM Assistant]
     O --> RF[Response Formatter]
     O --> CM[Context Manager]
+    O --> AG[API Gateway]
     
     O --> SA1[Sub-Agent 1]
     O --> SA2[Sub-Agent 2]


### PR DESCRIPTION
## Summary
- mention the API Gateway in REBUILD docs
- update module boundary docs for six core modules
- keep PRD and tooling docs consistent

## Testing
- `pip install -q -r backend/requirements.txt`
- `PYTHONPATH=backend pytest backend/tests/test_semantic_queries_consolidated.py::TestSemanticQueryMatchers::test_employee_count_query_improvement -q`

------
https://chatgpt.com/codex/tasks/task_b_685e82078668833292663128b894f990